### PR TITLE
Replace httpretty and requests-mock with responses

### DIFF
--- a/ckanext/datapackager/tests/controllers/test_datapackage.py
+++ b/ckanext/datapackager/tests/controllers/test_datapackage.py
@@ -2,7 +2,6 @@
 import json
 
 import nose.tools
-import ckanapi
 import datapackage
 import pytest
 
@@ -29,7 +28,6 @@ class TestDataPackageController():
 
         '''
         user = factories.Sysadmin()
-        api = ckanapi.TestAppCKAN(app, apikey=user['apikey'])
         dataset = factories.Dataset()
 
         # Add a resource with a linked-to, not uploaded, data file.
@@ -42,7 +40,7 @@ class TestDataPackageController():
         # Add a resource with an uploaded data file.
         csv_path = 'lahmans-baseball-database/AllstarFull.csv'
         csv_file = custom_helpers.get_csv_file(csv_path)
-        uploaded_resource = api.action.resource_create(
+        uploaded_resource = helpers.call_action('resource_create', {},
             package_id=dataset['id'],
             name='AllstarFull',
             url='_needed_for_ckan<2.6',

--- a/ckanext/datapackager/tests/lib/test_converter.py
+++ b/ckanext/datapackager/tests/lib/test_converter.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import nose.tools
-import httpretty
+import responses
 
 from ckan_datapackage_tools import converter
 import datapackage
@@ -452,7 +452,7 @@ class TestDataPackageToDatasetDict(object):
         nose.tools.assert_equals(result.get('resources')[0].get('name'),
                                  resource['title'])
 
-    @httpretty.activate
+    @responses.activate
     def test_resource_url(self):
         url = 'http://www.somewhere.com/data.csv'
         datapackage_dict = {
@@ -463,14 +463,14 @@ class TestDataPackageToDatasetDict(object):
                 {'path': url}
             ],
         }
-        httpretty.register_uri(httpretty.GET, url, body='')
+        responses.add(responses.GET, url, body='')
 
         dp = datapackage.DataPackage(datapackage_dict)
         result = converter.datapackage_to_dataset(dp)
         nose.tools.assert_equals(result.get('resources')[0].get('url'),
                                  datapackage_dict['resources'][0]['path'])
 
-    @httpretty.activate
+    @responses.activate
     def test_resource_url_is_set_to_its_remote_data_path(self):
         url = 'http://www.somewhere.com/data.csv'
         datapackage_dict = {
@@ -481,7 +481,7 @@ class TestDataPackageToDatasetDict(object):
                 {'path': 'data.csv'}
             ],
         }
-        httpretty.register_uri(httpretty.GET, url, body='')
+        responses.add(responses.GET, url, body='')
         dp = datapackage.DataPackage(
             datapackage_dict, base_path='http://www.somewhere.com')
         result = converter.datapackage_to_dataset(dp)

--- a/ckanext/datapackager/tests/lib/test_util.py
+++ b/ckanext/datapackager/tests/lib/test_util.py
@@ -1,11 +1,12 @@
 import os
 
 import nose.tools
-import ckanapi as ckanapi
 import pytest
 
 import ckan.tests.factories as factories
 
+
+import ckan.tests.helpers as helpers
 import ckanext.datapackager.lib.util as util
 import ckanext.datapackager.tests.helpers as custom_helpers
 import ckanext.datapackager.exceptions as exceptions
@@ -18,9 +19,8 @@ class TestResourceSchemaFieldCreate():
 
         user = factories.User()
         package = factories.Dataset(user=user)
-        api = ckanapi.TestAppCKAN(app, apikey=user['apikey'])
         csv_file = custom_helpers.get_csv_file('datetimes.csv')
-        resource = api.action.resource_create(
+        resource = helpers.call_action('resource_create', {},
             package_id=package['id'],
             upload=csv_file,
             url=''  # FIXME: See https://github.com/ckan/ckan/issues/2769

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,6 @@
 -r requirements.txt
-# nose==1.3.7
-ckanapi==4.6
-beautifulsoup4==4.5.1
-requests-mock==1.9.3
-reponses
+beautifulsoup4
+requests-mock
+responses
 pytest-ckan
 pytest-cov

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,6 @@
 ckanapi==4.6
 beautifulsoup4==4.5.1
 requests-mock==1.9.3
-httpretty
+reponses
 pytest-ckan
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+ckantoolkit
 python-slugify==1.2.4
 datapackage==1.1.3
 ckan-datapackage-tools==0.1.0


### PR DESCRIPTION
Use [responses](https://github.com/getsentry/responses) instead, which is what CKAN core uses

Also add a passthru setting so responses ignores the call to Solr made when
creating a dataset. This should fix this failures:

     requests_mock.exceptions.NoMockAddress: No mock address: GET http://solr:8983/solr/ckan/select/?q=name%3A%22e65c5686-a278-4a3e-aa81-36e070dbb419%22+OR+id%3A%22e65c5686-a278-4a3e-aa81-36e070dbb419%22&rows=1&wt=json&fq=site_id%3A%22test.ckan.net%22

Also use `helpers.call_action()` instead of ckanapi